### PR TITLE
feat: Add support for custom OpenAI API endpoint URL

### DIFF
--- a/openapi-models.sh
+++ b/openapi-models.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
 # Check script usage
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <OPENAI_API_KEY>"
-    echo "Example: $0 sk-your-api-key"
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <OPENAI_API_KEY> [ENDPOINT]"
+    echo "Example: $0 sk-your-api-key https://api.openai.com"
     exit 1
 fi
 
-# Receive API key as an argument
 API_KEY="$1"
+ENDPOINT="${2:-https://api.openai.com}"
 
 # Validate API key format (simple validation)
-if [[ ! "$API_KEY" =~ ^sk-[A-Za-z0-9]+ ]]; then
+if [[ "$ENDPOINT" == "https://api.openai.com" ]] && [[ ! "$API_KEY" =~ ^sk-[A-Za-z0-9]+ ]]; then
     echo "Error: Invalid OpenAI API key format. It should start with 'sk-'"
     exit 2
 fi
 
 # Call OpenAI API using curl
 echo "Retrieving OpenAI models list..."
-curl -s -X GET "https://api.openai.com/v1/models" \
+curl -s -X GET "$ENDPOINT/v1/models" \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer $API_KEY" \
      -H "user-agent: Obsidian-Summar/1.1.19" | \

--- a/src/audiohandler.ts
+++ b/src/audiohandler.ts
@@ -361,18 +361,21 @@ export class AudioHandler extends SummarViewContainer {
 	}
 
 	async callWhisperTranscription(requestbody: Blob, contentType: string): Promise<any> {
-		const response = await requestUrl({
-			url: "https://api.openai.com/v1/audio/transcriptions",
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${this.plugin.settings.openaiApiKey}`,
-				"Content-Type": contentType,
-			},
-			body: await requestbody.arrayBuffer(),
-		});
+        // 엔드포인트 설정 (비어있으면 기본값)
+        const endpoint = this.plugin.settings.openaiApiEndpoint?.trim() || "https://api.openai.com";
+        const url = `${endpoint.replace(/\/$/, "")}/v1/audio/transcriptions`;
+        const response = await requestUrl({
+            url: url,
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${this.plugin.settings.openaiApiKey}`,
+                "Content-Type": contentType,
+            },
+            body: await requestbody.arrayBuffer(),
+        });
 
-		return response.json;
-	}
+        return response.json;
+    }
 
 	////////////////////////////
 	async readFileAsBase64(filePath: string): Promise<{ base64:string; mimeType: string }> {

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -211,8 +211,12 @@ export async function fetchOpenai(plugin: SummarPlugin, openaiApiKey: string, bo
     SummarDebug.log(1, `openaiApiKey: ${openaiApiKey}`);
     SummarDebug.log(2, `bodyContent: ${bodyContent}`);
 
+    // 엔드포인트 설정 (비어있으면 기본값)
+    const endpoint = plugin.settings.openaiApiEndpoint?.trim() || "https://api.openai.com";
+    const url = `${endpoint.replace(/\/$/, "")}/v1/chat/completions`;
+
     const response = await SummarRequestUrl(plugin, {
-      url: "https://api.openai.com/v1/chat/completions",
+      url: url,
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,8 @@ import { StatusBar } from "./statusbar";
 export default class SummarPlugin extends Plugin {
   settings: PluginSettings = {
     openaiApiKey: "",
+    openaiApiEndpoint: "",
+
     googleApiKey: "",
     confluenceApiToken: "",
 

--- a/src/summarsettingtab.ts
+++ b/src/summarsettingtab.ts
@@ -314,7 +314,21 @@ async activateTab(tabId: string): Promise<void> {
           .onChange(async (value) => {
             this.plugin.settings.openaiApiKey = value;
           });
+        const textAreaEl = text.inputEl;
+        textAreaEl.style.width = "100%";
+      });
 
+    // OpenAI API Endpoint 입력란 추가
+    new Setting(containerEl)
+      .setName("OpenAI API Endpoint URL")
+      .setDesc("(Optional) Enter the OpenAI API endpoint URL.")
+      .addText((text) => {
+        text
+          .setPlaceholder("https://api.openai.com")
+          .setValue(this.plugin.settings.openaiApiEndpoint || "")
+          .onChange(async (value) => {
+            this.plugin.settings.openaiApiEndpoint = value;
+          });
         const textAreaEl = text.inputEl;
         textAreaEl.style.width = "100%";
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,8 @@ export interface PluginSettings {
   
   autoRecording: boolean;
   autoRecordOnZoomMeeting: boolean;
+
+  openaiApiEndpoint: string; // OpenAI API 엔드포인트 URL (기본값: https://api.openai.com)
 }
 
 export interface OpenAIResponse {


### PR DESCRIPTION
- Allow users to specify a custom OpenAI API endpoint URL in the settings (default: https://api.openai.com)
- Add OpenAI API Endpoint input field to the settings tab
- Update PluginSettings type and all internal API call logic to use the custom endpoint
- Update openapi-models.sh script to accept endpoint as an argument