### PR TITLE
fix: avoid plugin load failure on mobile by using dynamic import for webm-duration-fix

### DIFF
--- a/src/recordingmanager.ts
+++ b/src/recordingmanager.ts
@@ -7,7 +7,6 @@ import { RecordingTimer } from "./recordingtimer";
 import { SummarTimer } from "./summartimer";
 import { JsonBuilder } from "./jsonbuilder";
 import { exec } from "child_process";
-import fixWebmDuration from "webm-duration-fix/lib/index.js";
 
 export class AudioRecordingManager extends SummarViewContainer {
 	private timer: SummarTimer;
@@ -345,8 +344,10 @@ export class AudioRecordingManager extends SummarViewContainer {
 
 	private async saveFile(blob: Blob, fileName: string): Promise<void> {
 		// webm 파일이면 duration 메타데이터를 삽입
-		if (fileName.toLowerCase().endsWith('.webm')) {
+		if ((Platform.isMacOS && Platform.isDesktopApp) &&
+			fileName.toLowerCase().endsWith('.webm')) {
 			try {
+				const fixWebmDuration = (await import("webm-duration-fix/lib/index.js")).default;
 				const fixedBlob = await fixWebmDuration(blob);
 				blob = fixedBlob;
 				SummarDebug.log(1, `webm-duration-fix applied to: ${fileName}`);


### PR DESCRIPTION
- Removed static import of `webm-duration-fix` at the top of `recordingmanager.ts`.
- Changed to dynamic import inside `saveFile()` so that the module is only loaded on desktop when saving webm files.
- This prevents plugin loading errors on Obsidian mobile, where the dependency is not available.