### PR TITLE
fix: avoid plugin load failure on mobile by using dynamic import for …

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,5 +8,5 @@
   "isDesktopOnly": false,
   "minAppVersion": "0.13.0",
   "name": "Summar: AI-Powered Summarizer",
-  "version": "1.1.39"
+  "version": "1.1.40"
 }


### PR DESCRIPTION
…webm-duration-fix

- Removed static import of `webm-duration-fix` at the top of `recordingmanager.ts`.
- Changed to dynamic import inside `saveFile()` so that the module is only loaded on desktop when saving webm files.
- This prevents plugin loading errors on Obsidian mobile, where the dependency is not available.