### PR TITLE
Initialize settings properly to fix initialization error (issue #40)

### DIFF
--- a/src/pluginsettingsv2.ts
+++ b/src/pluginsettingsv2.ts
@@ -160,14 +160,14 @@ export class PluginSettingsV2 {
     // Recording 섹션 초기화
     Object.assign(this.recording, {
       autoRecordOnZoomMeeting: false,
-      selectedDeviceId: "",
+      selectedDeviceId: {},
       recordingDir: "",
       saveTranscriptAndRefineToNewNote: true,
       addLinkToDailyNotes: true,
       recordingUnit: 15,
       recordingLanguage: "ko-KR",
       sttModel: "",
-      sttPrompt: "",
+      sttPrompt: {},
       transcriptSummaryModel: "",
       transcriptSummaryPrompt: "",
       refineSummary: true,


### PR DESCRIPTION
Fix #40: I changed the resetToDefaults() as an object with the correct structure.

I also fixed the selectedDeviceId property to be an empty object {} instead of an empty string "" to match its expected type.
This should resolve the "Cannot create property 'gpt-4o-mini-transcribe' on string ''" error that was occurring during plugin initialization.