### PR TITLE
feat: add option to organize recordings by date hierarchy

### DIFF
--- a/src/pluginsettingsv2.ts
+++ b/src/pluginsettingsv2.ts
@@ -72,6 +72,7 @@ export class PluginSettingsV2 {
     customVocabulary: string;
     selectedDeviceId: { [deviceKey: string]: string };
     recordingDir: string;
+    organizeByDate: boolean;
     saveTranscriptAndRefineToNewNote: boolean;
     addLinkToDailyNotes: boolean;
     recordingUnit: number;
@@ -87,6 +88,7 @@ export class PluginSettingsV2 {
     customVocabulary: "",
     selectedDeviceId: {},
     recordingDir: "",
+    organizeByDate: false,
     saveTranscriptAndRefineToNewNote: true,
     addLinkToDailyNotes: true,
     recordingUnit: 15,

--- a/src/recordingmanager.ts
+++ b/src/recordingmanager.ts
@@ -252,7 +252,23 @@ export class AudioRecordingManager extends SummarViewContainer {
 		}
 
 		SummarDebug.log(1, `recordingDir: ${this.plugin.settingsv2.recording.recordingDir}`);
-		this.recordingPath = normalizePath(this.plugin.settingsv2.recording.recordingDir + "/" + this.timeStamp + folderSuffix);
+
+		// 날짜별 폴더 구조 생성 옵션이 활성화된 경우
+		let basePath = this.plugin.settingsv2.recording.recordingDir;
+		if (this.plugin.settingsv2.recording.organizeByDate) {
+			const now = new Date();
+			const year = now.getFullYear();
+			const month = String(now.getMonth() + 1).padStart(2, '0');
+			const day = String(now.getDate()).padStart(2, '0');
+			const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+			const dayName = dayNames[now.getDay()];
+
+			// YYYY/YYYY-MM/YYYY-MM-DD (Day) 형식으로 폴더 구조 생성
+			const datePath = `${year}/${year}-${month}/${year}-${month}-${day} (${dayName})`;
+			basePath = normalizePath(basePath + "/" + datePath);
+		}
+
+		this.recordingPath = normalizePath(basePath + "/" + this.timeStamp + folderSuffix);
 		await this.plugin.app.vault.adapter.mkdir(this.recordingPath);
 		SummarDebug.log(1,`recordingPath: ${this.recordingPath}`);
 

--- a/src/summarsettingtab.ts
+++ b/src/summarsettingtab.ts
@@ -1071,6 +1071,15 @@ async activateTab(tabId: string): Promise<void> {
         textAreaEl.style.width = "100%";
       });
 
+    new Setting(containerEl)
+      .setName("Organize recordings by date")
+      .setDesc("Automatically organize recordings into year/month/day subfolders")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settingsv2.recording.organizeByDate).onChange(async (value) => {
+          this.plugin.settingsv2.recording.organizeByDate = value;
+          await this.plugin.settingsv2.saveSettings();
+        }));
+
       new Setting(containerEl)
       .setName("Save to a New Note")
       .setDesc("Enable this toggle button to save the summary results to a new note.")


### PR DESCRIPTION
Add toggle option to automatically organize audio recordings into date-based subfolders for better file management.

Changes:
- Add organizeByDate setting to recording configuration
- Create date hierarchy: YYYY/YYYY-MM/YYYY-MM-DD (Day)
- Add toggle in settings UI below recording folder input
- Apply date path only when option is enabled

Example structure:
- Disabled: 02_Area/01_Meetings/2025-12-31_143022/
- Enabled: 02_Area/01_Meetings/2025/2025-12/2025-12-31 (Tue)/2025-12-31_143022/

🤖 Generated with [Claude Code](https://claude.com/claude-code)